### PR TITLE
Update setup.cfg to fix for CVE-2024-35195

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 0
 requires_dist =
     jmespath>=0.10.0,<=1.0.1
     python-dateutil>=2.8.2,<3.0.0
-    requests>=2.31.0,<3.0
+    requests>=2.32.2,<3.0
     urllib3>=1.26.18,<1.27 ; python_version < "3.10"
     urllib3>=1.26.18,<2.2 ; python_version >= "3.10"
 


### PR DESCRIPTION
There is a vulnerability in requests reported by mend, that is fixed starting from version 2.32.0, but since 2.32.0 and 2.32.1 are yanked, i think it should be safe to start from 2.32.2.